### PR TITLE
area type on AOIGenerator file and query is depreciated in Sentinel2 …

### DIFF
--- a/dataset_generation/AOIGenerator.py
+++ b/dataset_generation/AOIGenerator.py
@@ -31,7 +31,7 @@ class AOIGenerator:
         self.load_pois(pois, aoi_name_prefix)
         self.aoi_area = aoi_area_sqkm
         self.aois = AOIGenerator.generate_aois_from_pois(self.pois, self.aoi_area)
-        self.aois["area"] = self.aoi_area
+        self.aois["area"] = [self.aoi_area]*len(self.pois)
 
     def load_pois(self, pois, aoi_name_prefix=None):
         """ Loads the points of interest into a Pandas DataFrame.

--- a/dataset_generation/SentinelCatalogue.py
+++ b/dataset_generation/SentinelCatalogue.py
@@ -257,8 +257,8 @@ class SentinelCatalogue:
             self.data_collection,
             bbox=bounding_box,
             time=time_interval,
-            # distinct="date",
-            query={"eo:cloud_cover": {"lt": self.max_cloud_percentage}},
+            # distinct="date"
+            filter=f"eo:cloud_cover<{self.max_cloud_percentage}",
             fields={
                 "include": [
                     "id",


### PR DESCRIPTION
# 1 Area type

- repertory: dataset_generator
- file: AoiGenerator
- class: AoiGenerator
- function:__init__

- description: *self*.aois["area"] =self.aoi_area ==⇒ *self*.aois["area"] = *self*.aoi_area*np.ones(len(*self*.pois))
- self.aois["area"] receive a float but it wait a list which have the same lenght with the dataframe

# 2 query is depreciated

- repertory: dataset_generator
- file: SentinelCatalogue
- class: SentinelCatalogue
- function: generate_search_iterator
- description: query={"eo:cloud_cover": {"lt": self.max_cloud_percentage}} ==⇒ *filter*=f"eo:cloud_cover<{*self*.max_cloud_percentage}",