### PR TITLE
Update losses.py

### DIFF
--- a/src/losses.py
+++ b/src/losses.py
@@ -24,7 +24,7 @@ def tv_loss(x: Tensor) -> Tensor:
         Tensor of shape (batch_size,).
     """
     height, width = x.shape[-2:]
-    return kornia.losses.total_variation(x) / (height * width)
+    return (kornia.losses.total_variation(x) / (height * width)).mean(dim=1)
 
 
 def ms_ssim_loss(y_hat, y, window_size):


### PR DESCRIPTION
Copy of issue #10 

Hello,

in the tv_loss function,` kornia.losses.total_variation(x)` returns a tensor of shape _[Batch x Channels]_ instead of _[Batch]_. I think this behaviour is in line with the [documentation](https://kornia.readthedocs.io/en/latest/_modules/kornia/losses/total_variation.html) of kornia, but conflicts with the purpose and docstring of the tv_loss function.
This unexpected behaviour prevents benchmark training for batch sizes > 1.

Taking a mean over the channels of each image should be an appropriate fix, right?